### PR TITLE
don't assume fixed framerate

### DIFF
--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -8,8 +8,8 @@ export class Camera {
   worldDimensions: vec2
 
   // shake stuff
-  shakeStartTime: number
-  shakeLastMoveTime: number
+  ttl: number
+  cooldownTtl: number
   shakeOffset: vec2
 
   constructor(viewportSize: vec2, minWorldPos: vec2, worldDimensions: vec2) {
@@ -18,37 +18,33 @@ export class Camera {
     this.minWorldPos = minWorldPos
     this.worldDimensions = worldDimensions
 
-    this.shakeStartTime = 0
-    this.shakeLastMoveTime = 0
+    this.ttl = 0
+    this.cooldownTtl = 0
     this.shakeOffset = vec2.fromValues(0, 0)
   }
 
   shake(): void {
-    this.shakeStartTime = Date.now()
-    this.shakeLastMoveTime = 0
+    this.ttl = 0.25
+    this.cooldownTtl = 0
   }
 
-  update(): void {
-    if (this.shakeStartTime === 0) {
-      return
-    }
-
-    const now = Date.now()
-
-    if (this.shakeStartTime < now - 250) {
+  update(dt: number): void {
+    this.ttl -= dt
+    if (this.ttl <= 0) {
+      this.ttl = 0
       vec2.zero(this.shakeOffset)
-      this.shakeStartTime = 0
       return
     }
 
-    if (this.shakeLastMoveTime < now - 1000 / 60) {
+    this.cooldownTtl -= dt
+    if (this.cooldownTtl <= 0) {
+      this.cooldownTtl += 1 / 60
       this.shakeOffset = sample([
         vec2.fromValues(-3, 0),
         vec2.fromValues(3, 0),
         vec2.fromValues(0, -3),
         vec2.fromValues(0, 3),
       ])
-      this.shakeLastMoveTime = now
     }
   }
 

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -63,14 +63,14 @@ export class Game implements IGame {
     }
   }
 
-  update() {
-    this.entities.update(this)
+  update(dt: number) {
+    this.entities.update(this, dt)
 
     this.emitters = this.emitters.filter((e) => !e.dead)
-    this.emitters.forEach((e) => e.update())
+    this.emitters.forEach((e) => e.update(dt))
 
     this.camera.centerAt(this.player.transform.position)
-    this.camera.update()
+    this.camera.update(dt)
   }
 
   render(ctx: CanvasRenderingContext2D) {

--- a/src/entities/Entity.ts
+++ b/src/entities/Entity.ts
@@ -25,21 +25,21 @@ export class Entity implements IEntity {
 
   constructor() {}
 
-  update(game: IGame) {
+  update(game: IGame, dt: number) {
     this.transform?.update()
-    this.mover?.update(this, game)
-    this.wall?.update(this, game)
+    this.mover?.update(this, game, dt)
+    this.wall?.update(this, game, dt)
     this.wallCollider?.update(this, game)
-    this.shooter?.update(this, game)
-    this.damager?.update(this, game)
-    this.damageable?.update(this, game)
+    this.shooter?.update(this, game, dt)
+    this.damager?.update(this, game, dt)
+    this.damageable?.update(this, game, dt)
 
     // Should go after any business logic that modifies the
     // transform.
-    this.playfieldClamper?.update(this, game)
+    this.playfieldClamper?.update(this, game, dt)
 
     // Should be the very last thing to update.
-    this.prerender?.update(this, game)
+    this.prerender?.update(this, game, dt)
   }
 
   render(ctx: CanvasRenderingContext2D, camera: Camera): void {

--- a/src/entities/EntityManager.ts
+++ b/src/entities/EntityManager.ts
@@ -14,9 +14,9 @@ export class EntityManager implements IEntityManager {
   }
 
   // TODO: order by object type
-  update(g: IGame) {
+  update(g: IGame, dt: number) {
     Object.keys(this.entities).forEach((id) => {
-      this.entities[id].update(g)
+      this.entities[id].update(g, dt)
     })
 
     this.toDelete.forEach((id) => delete this.entities[id])

--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -10,7 +10,8 @@ import { radialTranslate2 } from '~/mathutil'
 import { IEntity } from '~/entities/interfaces'
 import { PlayfieldClamper } from './components/PlayfieldClamper'
 
-const PLAYER_SPEED = TILE_SIZE / 4
+const PLAYER_SPEED = 60 * (TILE_SIZE / 4)
+const PLAYER_ROT_SPEED = 1.25 * 2 * Math.PI // 1.5 rotations per second
 
 const keyMap = {
   up: 38, // UP
@@ -21,21 +22,21 @@ const keyMap = {
 }
 
 export class PlayerMover {
-  update(entity: IEntity, game: IGame) {
+  update(entity: IEntity, game: IGame, dt: number) {
     if (game.keyboard.downKeys.has(keyMap.up)) {
       radialTranslate2(
         entity.transform.position,
         entity.transform.position,
         entity.transform.orientation,
-        PLAYER_SPEED,
+        PLAYER_SPEED * dt,
       )
     }
 
     if (game.keyboard.downKeys.has(keyMap.right)) {
-      entity.transform.orientation += 0.1
+      entity.transform.orientation += PLAYER_ROT_SPEED * dt
     }
     if (game.keyboard.downKeys.has(keyMap.left)) {
-      entity.transform.orientation -= 0.1
+      entity.transform.orientation -= PLAYER_ROT_SPEED * dt
     }
   }
 }

--- a/src/entities/components/Damageable.ts
+++ b/src/entities/components/Damageable.ts
@@ -9,7 +9,7 @@ export class Damageable implements IDamageable {
     this.health = health
   }
 
-  update(entity: IEntity, game: IGame) {
+  update(entity: IEntity, game: IGame, _dt: number) {
     if (this.health <= 0) {
       game.entities.markForDeletion(entity)
     }

--- a/src/entities/components/PathRenderable.ts
+++ b/src/entities/components/PathRenderable.ts
@@ -2,7 +2,6 @@ import { path2 } from '~/path2'
 import { IEntity } from '~/entities/interfaces'
 import { IPathRenderable } from '~/entities/components/interfaces'
 import { Camera } from '~/Camera'
-import { vec2 } from 'gl-matrix'
 
 export class PathRenderable implements IPathRenderable {
   path: path2

--- a/src/entities/components/interfaces.ts
+++ b/src/entities/components/interfaces.ts
@@ -19,7 +19,7 @@ export interface IWallCollider {
 }
 
 export interface IGenericComponent {
-  update(e: IEntity, g: IGame): void
+  update(e: IEntity, g: IGame, dt: number): void
 }
 
 export interface IPathRenderable {

--- a/src/entities/interfaces.ts
+++ b/src/entities/interfaces.ts
@@ -15,7 +15,7 @@ export interface IEntityManager {
   register: (e: IEntity) => void
   markForDeletion: (e: IEntity) => void
 
-  update: (game: IGame) => void
+  update: (game: IGame, dt: number) => void
   render: (ctx: CanvasRenderingContext2D, camera: Camera) => void
 }
 
@@ -31,6 +31,6 @@ export interface IEntity {
   prerender?: IGenericComponent
   pathRenderable?: IPathRenderable
 
-  update: (g: IGame) => void
+  update: (g: IGame, dt: number) => void
   render: (ctx: CanvasRenderingContext2D, camera: Camera) => void
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,12 +54,24 @@ const map = {
 `,
 }
 
+/**
+ * Return the current timestamp in seconds, with sub-millisecond precision.
+ */
+const curTimeSeconds = (): number => {
+  return window.performance.now() / 1000
+}
+
 const ctx = canvas.getContext('2d')
 const game = new Game(map, viewportDimensions)
+let prevFrameTime = curTimeSeconds()
 
 function gameLoop() {
   requestAnimationFrame(gameLoop)
-  game.update()
+  const now = curTimeSeconds()
+  const dt = now - prevFrameTime
+  prevFrameTime = now
+
+  game.update(dt)
   game.render(ctx)
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { VIEWPORT_TILE_DIMENSIONS, TILE_SIZE } from '~/constants'
 import { Game } from '~/Game'
 import { vec2 } from 'gl-matrix'
+import * as time from '~/time'
 
 const canvas = document.createElement('canvas')
 document.body.appendChild(canvas)
@@ -54,20 +55,14 @@ const map = {
 `,
 }
 
-/**
- * Return the current timestamp in seconds, with sub-millisecond precision.
- */
-const curTimeSeconds = (): number => {
-  return window.performance.now() / 1000
-}
-
 const ctx = canvas.getContext('2d')
 const game = new Game(map, viewportDimensions)
-let prevFrameTime = curTimeSeconds()
+let prevFrameTime = time.current()
 
 function gameLoop() {
   requestAnimationFrame(gameLoop)
-  const now = curTimeSeconds()
+
+  const now = time.current()
   const dt = now - prevFrameTime
   prevFrameTime = now
 

--- a/src/time.ts
+++ b/src/time.ts
@@ -1,0 +1,6 @@
+/**
+ * Return the current timestamp in seconds, with sub-millisecond precision.
+ */
+export const current = (): number => {
+  return window.performance.now() / 1000
+}

--- a/src/tools/particles/Controls.tsx
+++ b/src/tools/particles/Controls.tsx
@@ -34,25 +34,25 @@ export const Controls = (props: {
       </div>
 
       <div>
-        <label htmlFor="emitterLifespan">Emitter lifespan</label>
+        <label htmlFor="spawnTtl">Particle spawn TTL</label>
         <input
           type="number"
-          name="emitterLifespan"
-          value={config.emitterLifespan}
+          name="spawnTtl"
+          value={config.spawnTtl}
           onChange={(e) => {
-            updateConfig('emitterLifespan', parse(e.target.value))
+            updateConfig('spawnTtl', parse(e.target.value))
           }}
         ></input>
       </div>
 
       <div>
-        <label htmlFor="particleLifespan">Particle lifespan</label>
+        <label htmlFor="particleTtl">Per-particle TTL</label>
         <input
           type="number"
-          name="particleLifespan"
-          value={config.particleLifespan}
+          name="particleTtl"
+          value={config.particleTtl}
           onChange={(e) => {
-            updateConfig('particleLifespan', parse(e.target.value))
+            updateConfig('particleTtl', parse(e.target.value))
           }}
         ></input>
       </div>

--- a/src/tools/particles/index.tsx
+++ b/src/tools/particles/index.tsx
@@ -6,6 +6,7 @@ import { Controls } from '~/tools/particles/Controls'
 import { Config } from '~/tools/particles/interfaces'
 import { ParticleEmitter } from '~particles/ParticleEmitter'
 import { Camera } from '~/Camera'
+import * as time from '~/time'
 
 const storage = window.localStorage
 const storedConfig = storage.getItem('config')
@@ -14,14 +15,14 @@ let globalConfig: Config = storedConfig
   ? JSON.parse(storedConfig)
   : {
       backgroundColor: '#888',
-      emitterLifespan: 1000,
-      particleLifespan: 1000,
+      spawnTtl: 1,
+      particleTtl: 1,
       orientation: 0,
       arc: Math.PI,
-      particleRate: 2,
+      particleRate: 120,
       particleRadius: 2,
-      particleSpeedMin: 1,
-      particleSpeedMax: 4,
+      particleSpeedMin: 60,
+      particleSpeedMax: 240,
       colors: ['#FF4500', '#FFA500', '#FFD700', '#000'],
     }
 
@@ -54,8 +55,8 @@ const makeEmitter = () => {
   return new ParticleEmitter({
     position: vec2.fromValues(200, 200),
 
-    emitterLifespan: globalConfig.emitterLifespan,
-    particleLifespan: globalConfig.particleLifespan,
+    spawnTtl: globalConfig.spawnTtl,
+    particleTtl: globalConfig.particleTtl,
     orientation: globalConfig.orientation,
     arc: globalConfig.arc,
     particleRadius: globalConfig.particleRadius,
@@ -69,13 +70,19 @@ const makeEmitter = () => {
 }
 
 let emitter = makeEmitter()
+let prevFrameTime = time.current()
+
 function gameLoop() {
   requestAnimationFrame(gameLoop)
+
+  const now = time.current()
+  const dt = now - prevFrameTime
+  prevFrameTime = now
 
   ctx.fillStyle = globalConfig.backgroundColor
   ctx.fillRect(0, 0, 400, 400)
 
-  emitter.update()
+  emitter.update(dt)
   emitter.render(ctx, camera)
 
   if (emitter.dead) {

--- a/src/tools/particles/interfaces.ts
+++ b/src/tools/particles/interfaces.ts
@@ -1,13 +1,13 @@
 export interface Config {
   backgroundColor: string
 
-  emitterLifespan: number
-  particleLifespan: number
+  spawnTtl: number
+  particleTtl: number
   orientation: number
   arc: number
   particleRate: number
   particleRadius: number
   particleSpeedMin: number
   particleSpeedMax: number
-  colors: string
+  colors: string[]
 }


### PR DESCRIPTION
For review: the [whitespace-ignoring diff](https://github.com/jeffanddom/yolorts/pull/9/files?w=1) is easier to read.

This change introduces the concept of passing time deltas to all `update` functions. This has the following side-effects:

1. Game update logic should no longer directly call `Date.now()` to sample the current timestamp.
2. All rates should be expressed as "units per second" or "events per second", as opposed to "units per frame" or "events per frame".

- Note that this does not preclude a fixed framerate (you can always pass the same time delta to every update).
- I did make one significant "bugfix" in the process of doing this refactor: I noticed that the particle emitter was displacing particles using a random displacement per frame, rather than giving a randomly-initialized constant velocity to each particle. I updated the logic to do the latter, and did some parameter tuning so as not to disrupt the effects too much.
- For more reading on time and gameloops, [this Glenn Fielder](https://gafferongames.com/post/fix_your_timestep/) article seems authoritative.