### PR TITLE
add sketch of map editing functionality

### DIFF
--- a/src/Keyboard.ts
+++ b/src/Keyboard.ts
@@ -1,18 +1,31 @@
-import { IKeyboard } from '~/interfaces'
+/**
+ * TODO: we should consume DOM events using a queue, and apply the queued events
+ * to internal state on a frame-by-frame basis.
+ */
 
-export class Keyboard implements IKeyboard {
+export class Keyboard {
   downKeys: Set<number>
+  upKeys: Set<number>
 
   constructor() {
     this.downKeys = new Set()
+    this.upKeys = new Set()
+
     document.addEventListener('focusout', () => {
       this.downKeys.clear()
+      this.upKeys.clear()
     })
     document.addEventListener('keydown', (event) => {
       this.downKeys.add(event.which)
+      this.upKeys.delete(event.which)
     })
     document.addEventListener('keyup', (event) => {
       this.downKeys.delete(event.which)
+      this.upKeys.add(event.which)
     })
+  }
+
+  update(): void {
+    this.upKeys.clear()
   }
 }

--- a/src/Mouse.ts
+++ b/src/Mouse.ts
@@ -1,0 +1,17 @@
+import { vec2 } from 'gl-matrix'
+
+export class Mouse {
+  private pos: vec2
+
+  constructor() {
+    this.pos = vec2.create()
+
+    document.addEventListener('mousemove', (event) => {
+      this.pos = vec2.fromValues(event.clientX, event.clientY)
+    })
+  }
+
+  getPos(): vec2 {
+    return vec2.clone(this.pos)
+  }
+}

--- a/src/Playfield.ts
+++ b/src/Playfield.ts
@@ -1,18 +1,19 @@
-import { Terrain, Tile, IPlayfield } from '~/interfaces'
+import { Tile, IPlayfield } from '~/interfaces'
 import { TILE_SIZE } from '~/constants'
 import { vec2 } from 'gl-matrix'
 import { Camera } from '~/Camera'
+import * as map from '~/map/interfaces'
 
-const terrainByEncoding: { [key: string]: Terrain } = {
-  '.': Terrain.Grass,
-  '~': Terrain.River,
-  '^': Terrain.Mountain,
+const terrainByEncoding: { [key: string]: map.Terrain } = {
+  '.': map.Terrain.Grass,
+  '~': map.Terrain.River,
+  '^': map.Terrain.Mountain,
 }
 
-const deserializeTerrain = (s: string): Terrain => {
+const deserializeTerrain = (s: string): map.Terrain => {
   const t = terrainByEncoding[s]
   if (t === undefined) {
-    return Terrain.Unknown
+    return map.Terrain.Unknown
   }
   return t
 }
@@ -64,21 +65,21 @@ export class Playfield implements IPlayfield {
       for (let j = 0; j < tileWidth; j++) {
         const x = j * TILE_SIZE
         switch (this.tiles[i][j].type) {
-          case Terrain.Grass:
+          case map.Terrain.Grass:
             ctx.fillStyle = '#7EC850'
             break
-          case Terrain.Mountain:
+          case map.Terrain.Mountain:
             ctx.fillStyle = '#5B5036'
             break
-          case Terrain.River:
+          case map.Terrain.River:
             ctx.fillStyle = '#2B5770'
             break
-          case Terrain.Unknown:
+          case map.Terrain.Unknown:
             ctx.fillStyle = '#FF00FF'
             break
         }
 
-        const renderPos = camera.toRenderPos(vec2.fromValues(x, y))
+        const renderPos = camera.w2v(vec2.fromValues(x, y))
         ctx.fillRect(renderPos[0], renderPos[1], TILE_SIZE, TILE_SIZE)
       }
     }

--- a/src/entities/components/PathRenderable.ts
+++ b/src/entities/components/PathRenderable.ts
@@ -18,7 +18,7 @@ export class PathRenderable implements IPathRenderable {
         path2.rotate(this.path, e.transform.orientation),
         e.transform.position,
       )
-      .map((p) => camera.toRenderPos(p))
+      .map((p) => camera.w2v(p))
 
     ctx.fillStyle = this.fillStyle
     ctx.beginPath()

--- a/src/entities/components/WallCollider.ts
+++ b/src/entities/components/WallCollider.ts
@@ -100,7 +100,6 @@ export class WallCollider implements IWallCollider {
 
     // Track walls that were collided with
     this.collidedWalls = collided.map((c) => c[0])
-    console.log(this.collidedWalls)
 
     // Halt motion for collided edges
     collided.forEach((collision) => {

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -1,0 +1,1 @@
+export * as types from '~/entities/types'

--- a/src/entities/types.ts
+++ b/src/entities/types.ts
@@ -1,0 +1,46 @@
+import { IEntity } from '~/entities/interfaces'
+import { makeWall } from '~/entities/Wall'
+import { makeTurret } from '~/entities/turret'
+import { makePlayer } from '~/entities/player'
+
+export enum Type {
+  PLAYER = 'PLAYER',
+  TURRET = 'TURRET',
+  WALL = 'WALL',
+}
+
+const entityTypeDefinitions = {
+  [Type.PLAYER]: { make: makePlayer, serialized: 'p' },
+  [Type.TURRET]: { make: makeTurret, serialized: 't' },
+  [Type.WALL]: { make: makeWall, serialized: 'w' },
+}
+
+export const make = (t: Type): IEntity => {
+  for (let k in entityTypeDefinitions) {
+    if (k !== t) {
+      continue
+    }
+    return entityTypeDefinitions[k].make()
+  }
+  throw new Error(`invalid entity type ${t}`)
+}
+
+export const serialize = (t: Type): string => {
+  for (let k in entityTypeDefinitions) {
+    if (k !== t) {
+      continue
+    }
+    return entityTypeDefinitions[k].serialized
+  }
+  throw new Error(`invalid entity type ${t}`)
+}
+
+export const deserialize = (s: string): Type | undefined => {
+  for (let k in entityTypeDefinitions) {
+    const c = k as keyof typeof Type
+    if (entityTypeDefinitions[c].serialized === s) {
+      return Type[c]
+    }
+  }
+  return undefined
+}

--- a/src/index.html
+++ b/src/index.html
@@ -17,8 +17,9 @@
 
     <hr />
 
-    <div>
-      <a href="~/tools/particles/index.html">Particle creator</a>
-    </div>
+    <ul>
+      <li><a href="~/tools/map/index.html">Map editor</a></li>
+      <li><a href="~/tools/particles/index.html">Particle creator</a></li>
+    </ul>
   </body>
 </html>

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -2,16 +2,11 @@ import { ParticleEmitter } from '~/particles/ParticleEmitter'
 import { IEntityManager } from '~/entities/interfaces'
 import { Camera } from '~/Camera'
 import { vec2 } from 'gl-matrix'
-
-export enum Terrain {
-  Mountain,
-  River,
-  Grass,
-  Unknown,
-}
+import * as map from '~/map/interfaces'
+import { Keyboard } from '~Keyboard'
 
 export interface Tile {
-  type: Terrain
+  type: map.Terrain
 }
 
 export enum Direction {
@@ -34,14 +29,10 @@ export interface IPlayfield {
   render: (ctx: CanvasRenderingContext2D, camera: Camera) => void
 }
 
-export interface IKeyboard {
-  downKeys: Set<number>
-}
-
 export interface IGame {
   playfield: IPlayfield
   entities: IEntityManager
-  keyboard: IKeyboard
+  keyboard: Keyboard
   emitters: ParticleEmitter[]
   camera: Camera
 }

--- a/src/map/interfaces.ts
+++ b/src/map/interfaces.ts
@@ -1,0 +1,27 @@
+import { vec2 } from 'gl-matrix'
+
+import * as entities from '~/entities'
+
+export enum Terrain {
+  Mountain,
+  River,
+  Grass,
+  Unknown,
+}
+
+export class Map {
+  dimensions: vec2 // width/height in tiles
+  origin: vec2 // tile coordinate of NW tile
+  terrain: Terrain[]
+  entities: entities.types.Type[]
+
+  constructor(dimensions: vec2) {
+    this.dimensions = dimensions
+    this.origin = vec2.negate(
+      vec2.create(),
+      vec2.round(vec2.create(), vec2.scale(vec2.create(), dimensions, 0.5)),
+    )
+    this.terrain = new Array(dimensions[0] * dimensions[1])
+    this.entities = new Array(dimensions[0] * dimensions[1])
+  }
+}

--- a/src/mathutil.ts
+++ b/src/mathutil.ts
@@ -1,5 +1,13 @@
 import { vec2 } from 'gl-matrix'
 
+export const clamp = (v: number, range: [number, number]): number => {
+  return Math.min(Math.max(range[0], v), range[1])
+}
+
+export const clamp2 = (out: vec2, v: vec2, range: [vec2, vec2]): vec2 => {
+  return vec2.min(out, vec2.max(out, v, range[0]), range[1])
+}
+
 export const lerp = (min: number, max: number, alpha: number): number => {
   return min + alpha * (max - min)
 }

--- a/src/particles/ParticleEmitter.ts
+++ b/src/particles/ParticleEmitter.ts
@@ -100,7 +100,7 @@ export class ParticleEmitter {
 
   render(ctx: CanvasRenderingContext2D, camera: Camera): void {
     this.particles.forEach((p) => {
-      const renderPos = camera.toRenderPos(p.position)
+      const renderPos = camera.w2v(p.position)
 
       ctx.fillStyle = p.color
       ctx.beginPath()

--- a/src/tools/map/index.html
+++ b/src/tools/map/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body,
+      canvas {
+        margin: 0 auto;
+        padding: 0;
+        display: block;
+      }
+
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+          Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="controls" />
+    <script src="~/tools/map/index.tsx"></script>
+  </body>
+</html>

--- a/src/tools/map/index.tsx
+++ b/src/tools/map/index.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react'
+import * as ReactDOM from 'react-dom'
+import { vec2 } from 'gl-matrix'
+import * as time from '~/time'
+import { Editor } from './Editor'
+import { Map } from '~map/interfaces'
+
+const canvas = document.createElement('canvas')
+document.body.prepend(canvas)
+canvas.width = 400
+canvas.height = 400
+
+const editor = new Editor({
+  canvas: canvas,
+  map: new Map(vec2.fromValues(64, 64)),
+})
+let prevFrameTime = time.current()
+
+function gameLoop() {
+  requestAnimationFrame(gameLoop)
+
+  const now = time.current()
+  const dt = now - prevFrameTime
+  prevFrameTime = now
+
+  editor.update(dt)
+  editor.render()
+}
+
+gameLoop()


### PR DESCRIPTION
Controls:

- WASD to move around
- Q to zoom out
- E to zoom in
- Spacebar to paint
- R to cycle through terrain types
- F to cycle through entity types. Entities can be painted one per tile, and are NOT rendered in this commit.

Lots still to do in future PRs:

- Render entities
- Show brush state in text overlays or React components
- Dump current editor state to local storage
- Dump current editor state to JSON (clipboard?)
- Abstract path + fillstyle rendering so we can share entity rendering code between game and editor (for both terrain and entities)