### PR TITLE
example ECS patterns

### DIFF
--- a/src/entities/Bullet.ts
+++ b/src/entities/Bullet.ts
@@ -1,7 +1,7 @@
 import { vec2 } from 'gl-matrix'
 
 import { TILE_SIZE } from '~/constants'
-import { IDamager, IGenericComponent } from '~/entities/components/interfaces'
+import { IDamager, IMotionLogic } from '~/entities/components/interfaces'
 import { PathRenderable } from '~/entities/components/PathRenderable'
 import { Transform } from '~/entities/components/Transform'
 import { Entity } from '~/entities/Entity'
@@ -14,7 +14,7 @@ import { path2 } from '~/util/path2'
 
 const BULLET_SPEED = 60 * (TILE_SIZE / 8)
 
-class BulletMover implements IGenericComponent {
+class MotionLogic implements IMotionLogic {
   origin: vec2
   range: number
 
@@ -23,16 +23,16 @@ class BulletMover implements IGenericComponent {
     this.range = range
   }
 
-  update(entity: Entity, game: Game, dt: number): void {
+  update(transform: Transform, entityId: string, game: Game, dt: number): void {
     radialTranslate2(
-      entity.transform!.position,
-      entity.transform!.position,
-      entity.transform!.orientation,
+      transform.position,
+      transform.position,
+      transform.orientation,
       BULLET_SPEED * dt,
     )
 
-    if (vec2.distance(entity.transform!.position, this.origin) >= this.range) {
-      game.entities.markForDeletion(entity)
+    if (vec2.distance(transform.position, this.origin) >= this.range) {
+      game.entities.markForDeletion(entityId)
       return
     }
   }
@@ -95,7 +95,7 @@ class BulletDamager implements IDamager {
 
       // Perform damage, kill bullet
       c.damageable.health = c.damageable.health - this.damageValue
-      game.entities.markForDeletion(entity)
+      game.entities.markForDeletion(entity.id)
       return
     }
   }
@@ -116,7 +116,7 @@ export const makeBullet = ({
   e.transform.position = vec2.clone(position)
   e.transform.orientation = orientation
 
-  e.mover = new BulletMover(vec2.clone(position), range)
+  e.motionLogic = new MotionLogic(vec2.clone(position), range)
   e.renderable = new PathRenderable(
     path2.fromValues([
       [0, -TILE_SIZE * 0.5],

--- a/src/entities/Entity.ts
+++ b/src/entities/Entity.ts
@@ -6,6 +6,7 @@ import { WallCollider } from './components/WallCollider'
 import {
   IDamager,
   IGenericComponent,
+  IMotionLogic,
   IRenderable,
 } from '~/entities/components/interfaces'
 import { Transform } from '~/entities/components/Transform'
@@ -14,7 +15,7 @@ import { Game } from '~/Game'
 export class Entity {
   id: string
   transform?: Transform
-  mover?: IGenericComponent
+  motionLogic?: IMotionLogic
   shooter?: IGenericComponent
   wallCollider?: WallCollider
   wall?: IGenericComponent
@@ -29,8 +30,6 @@ export class Entity {
   }
 
   update(game: Game, dt: number): void {
-    this.transform?.update()
-    this.mover?.update(this, game, dt)
     this.wall?.update(this, game, dt)
     this.wallCollider?.update(this, game)
     this.shooter?.update(this, game, dt)

--- a/src/entities/EntityManager.ts
+++ b/src/entities/EntityManager.ts
@@ -1,6 +1,7 @@
 import { Entity } from '~/entities/Entity'
 import { Game } from '~/Game'
 import { Renderable } from '~/renderer/interfaces'
+import * as systems from '~/systems'
 
 export class EntityManager {
   entities: { [key: string]: Entity }
@@ -13,6 +14,9 @@ export class EntityManager {
 
   // TODO: order by object type
   update(g: Game, dt: number): void {
+    systems.transformInit(g)
+    systems.motion(g, dt)
+
     Object.keys(this.entities).forEach((id) => {
       this.entities[id].update(g, dt)
     })
@@ -37,7 +41,7 @@ export class EntityManager {
     this.entities[e.id] = e
   }
 
-  markForDeletion(entity: Entity): void {
-    this.toDelete.push(entity.id)
+  markForDeletion(id: string): void {
+    this.toDelete.push(id)
   }
 }

--- a/src/entities/components/Damageable.ts
+++ b/src/entities/components/Damageable.ts
@@ -25,7 +25,7 @@ export class Damageable {
 
   update(entity: Entity, game: Game, _dt: number): void {
     if (this.health <= 0) {
-      game.entities.markForDeletion(entity)
+      game.entities.markForDeletion(entity.id)
 
       const emitterPos = radialTranslate2(
         vec2.create(),

--- a/src/entities/components/interfaces.ts
+++ b/src/entities/components/interfaces.ts
@@ -1,5 +1,7 @@
 import { vec2 } from 'gl-matrix'
 
+import { Transform } from './Transform'
+
 import { Entity } from '~/entities/Entity'
 import { Game } from '~/Game'
 import { Hitbox } from '~/Hitbox'
@@ -19,4 +21,8 @@ export interface IDamager extends IGenericComponent {
   hitbox: Hitbox
 
   aabb(e: Entity): [vec2, vec2]
+}
+
+export interface IMotionLogic {
+  update(t: Transform, entityId: string, g: Game, dt: number): void
 }

--- a/src/entities/player/MotionLogic.ts
+++ b/src/entities/player/MotionLogic.ts
@@ -1,5 +1,7 @@
+import { IMotionLogic } from '../components/interfaces'
+import { Transform } from '../components/Transform'
+
 import { TILE_SIZE } from '~/constants'
-import { Entity } from '~/entities/Entity'
 import { Game } from '~/Game'
 import { radialTranslate2 } from '~/util/math'
 import { rotate } from '~/util/rotator'
@@ -14,8 +16,13 @@ const keyMap = {
   moveRight: 65,
 }
 
-export class Mover {
-  update(entity: Entity, game: Game, dt: number): void {
+export class MotionLogic implements IMotionLogic {
+  update(
+    transform: Transform,
+    _entityId: string,
+    game: Game,
+    dt: number,
+  ): void {
     // Direction controls
     let angle
 
@@ -42,16 +49,16 @@ export class Mover {
     }
 
     if (angle !== undefined) {
-      entity.transform!.orientation = rotate({
-        from: entity.transform!,
+      transform.orientation = rotate({
+        from: transform,
         to: angle,
         speed: PLAYER_ROT_SPEED,
         dt,
       })
 
       radialTranslate2(
-        entity.transform!.position,
-        entity.transform!.position,
+        transform.position,
+        transform.position,
         angle,
         PLAYER_SPEED * dt,
       )

--- a/src/entities/player/index.ts
+++ b/src/entities/player/index.ts
@@ -6,7 +6,7 @@ import { PlayfieldClamper } from '~/entities/components/PlayfieldClamper'
 import { Transform } from '~/entities/components/Transform'
 import { WallCollider } from '~/entities/components/WallCollider'
 import { Entity } from '~/entities/Entity'
-import { Mover } from '~/entities/player/Mover'
+import { MotionLogic } from '~/entities/player/MotionLogic'
 import { PlayerRenderables } from '~/entities/player/PlayerRenderables'
 import { Shooter } from '~/entities/player/Shooter'
 import { Hitbox } from '~/Hitbox'
@@ -20,7 +20,7 @@ export const makePlayer = (_model: {
 
   const e = new Entity()
   e.transform = new Transform()
-  e.mover = new Mover()
+  e.motionLogic = new MotionLogic()
   e.shooter = shooter
   e.wallCollider = new WallCollider()
   e.damageable = new Damageable(

--- a/src/entities/turret/index.ts
+++ b/src/entities/turret/index.ts
@@ -3,7 +3,10 @@ import { vec2 } from 'gl-matrix'
 import { TILE_SIZE } from '~/constants'
 import { makeBullet } from '~/entities/Bullet'
 import { Damageable } from '~/entities/components/Damageable'
-import { IGenericComponent } from '~/entities/components/interfaces'
+import {
+  IGenericComponent,
+  IMotionLogic,
+} from '~/entities/components/interfaces'
 import { PathRenderable } from '~/entities/components/PathRenderable'
 import { Transform } from '~/entities/components/Transform'
 import { Entity } from '~/entities/Entity'
@@ -16,11 +19,11 @@ import { rotate } from '~/util/rotator'
 
 const TURRET_ROT_SPEED = Math.PI / 2
 
-class Mover implements IGenericComponent {
-  update(e: Entity, g: Game, dt: number): void {
-    e.transform!.orientation = rotate({
-      from: e.transform!,
-      to: g.player.unwrapOr(e).transform!.position,
+class MotionLogic implements IMotionLogic {
+  update(transform: Transform, _entityId: string, g: Game, dt: number): void {
+    transform.orientation = rotate({
+      from: transform,
+      to: g.player.unwrap().transform!.position,
       speed: TURRET_ROT_SPEED,
       dt,
     })
@@ -92,7 +95,7 @@ export const makeTurret = (model: {
   const e = new Entity()
   e.transform = new Transform()
 
-  e.mover = new Mover()
+  e.motionLogic = new MotionLogic()
   e.shooter = new Shooter()
 
   e.wall = {

--- a/src/systems/index.ts
+++ b/src/systems/index.ts
@@ -1,0 +1,2 @@
+export { update as motion } from '~/systems/motion'
+export { update as transformInit } from '~/systems/transformInit'

--- a/src/systems/motion.ts
+++ b/src/systems/motion.ts
@@ -1,0 +1,12 @@
+import { Game } from '~/Game'
+
+export const update = (g: Game, dt: number): void => {
+  for (const id in g.entities.entities) {
+    const e = g.entities.entities[id]
+    if (!e.transform || !e.motionLogic) {
+      continue
+    }
+
+    e.motionLogic.update(e.transform, id, g, dt)
+  }
+}

--- a/src/systems/transformInit.ts
+++ b/src/systems/transformInit.ts
@@ -1,0 +1,12 @@
+import { Game } from '~/Game'
+
+export const update = (g: Game): void => {
+  for (const id in g.entities.entities) {
+    const e = g.entities.entities[id]
+    if (!e.transform) {
+      continue
+    }
+
+    e.transform.previousPosition = e.transform.position
+  }
+}


### PR DESCRIPTION
All of those "your components are possibly null!" type errors made me wonder if there was a way to get rid of them in a somewhat elegant way. I'm not sure if this version succeeds, but I think the example illustrates the benefits and the pitfalls.

### Systems: a new type of update architecture

In this PR, we're implementing the beginnings of an ECS system. Before, we just had the "E" and the "C", but in this PR, I've introduced the idea of "S", or system. The overall idea here is to gradually move away from an entity class that handles updates and renders, and instead just have tables of components, keyed by entity IDs.

This is almost bringing a web development style to programming a game. In web development, you split up your state changes into little interactions and API calls, and each of those performs writes into a centralized store.

Probably the best place to start is `EntityManager#update`. I went ahead and replaced the first two component updates, `transform` and `mover`, with equivalent systems, called `transformInit` and `motion`. Note that I only applied this pattern to a couple pieces of business logic. Applying it to all of our components would've taken a lot of time, and wasn't worth it when I was just trying to give an example.

Each system iterates over every entity, and runs some logic if the entity happens to carry the components that the system needs for updates. In the other ECS systems we've looked at, there was a fancy querying system that did some logical joins, but here, I think something far simpler would suffice: we just let each system use its own logic to discover the entities it wants to update.

The difference between the system names and the component names is significant. You can think of systems as your business logic, and components as your data. The classic example is `Transform`, which is as close to a dumb container of data as we've got. Following the web analogies, the systems are controllers and service objects, and components are your logic-less models or database tables.

What are the results of this?

- We eliminate null reference assertions in the business logic. It's not magical: we do this by literally checking each entity for the right components before running the business logic.
- We have moved business logic away from the components. This is might be more of a complexity than a benefit if you end up having lots of systems that only use a single component. `transformInit` is an example of a system that only reads one component. However, I think most logic ends up reading and writing state that comes from multiple components.
- We push the ordering of granular updates up a level, from `Entity#update` to `EntityManager`. Remember, eventually, there will be no entity, so those updates need to go somewhere.

### Adding per-entity variation inside the same system

In many cases, differences in behavior can be sufficiently described by _parameters_, which is more or less how our particle emitters work. All emitters have the same code, but they will be configured with different parameters.

However, this is not always going to be the case--the motion of bullets, players, and turrets are too different to capture in just a few properties.

So, I fibbed a bit when I said that components are just data. In fact, the `MotionLogic` component seems to be exactly the opposite! It is just an interface with an update function that takes a `Transform`, and then some common args: an entity ID, the game, and the time delta.

`MotionLogic` is consumed by the `motion` system. It allows the `motion` system to execute different behavior between different entities. But even if the behaviors vary, what each `MotionLogic` component has in common is the following:

- They share the same dependencies, i.e. they all take a `Transform` and an `entityId`.
- They are all updated as a batch at a particular moment in the game loop.

If you have some behavior where _both_ of those things need to be different, then we have justified the creation of a _different system_.

I sort of suspect that many systems will end up having one "brain" component (such as `MotionLogic`) that allows for per-entity variation. Again, each "brain" within a system might have different behavior, but they'll all share the same dependencies, and they will all get updated together as a system.

### Some stuff that's not so great

There are a few ugly parts of this:

- In the first place, it's a lot of classes and little snippets of code, scattered all over the place.
- Notice how `MotionLogic` takes an `entityId`, but only one of the three instances (the bullet's `MotionLogic`) actually needs it.
- Even though we've eliminated null assertions, we still have nothing guaranteeing that the entity was set up correctly. In fact, this pattern might paper over some problems. For example, you could create a `MotionLogic` component but fail to create a `Transform` on the same entity. The system will prevent null dereferences, but you now have a buggy entity.
- This is all great if you want to update a single entity, but what happens if you need to get information about _another_ entity? You can see this in the turret's `MoveLogic`--it needs to point at the player, so it needs the player's `Transform`. What if that entity ends up not having the component you need? I think this may point to the need for a more generic querying function (e.g., "I need the transform for the entity tagged as 'player', and I need to do something in case we can't find one"). But I think more generally, "eliminating nulls" _in itself_ does not seem like not a great justification for this architecture.