### PR TITLE
refactor: move builder input handling to playerInput system

### DIFF
--- a/src/entities/Entity.ts
+++ b/src/entities/Entity.ts
@@ -7,7 +7,7 @@ import { IRenderable } from '~/components/IRenderable'
 import { Team } from '~/components/team'
 import { Transform } from '~/components/Transform'
 import { Hitbox } from '~/Hitbox'
-import { BuilderComponent } from '~/systems/builder'
+import { BuilderComponent, BuilderCreator } from '~/systems/builder'
 import { PickupType } from '~/systems/pickups'
 import { ShooterComponent } from '~/systems/shooter'
 import { TurretComponent } from '~/systems/turret'
@@ -28,6 +28,7 @@ export class Entity {
   wallCollider: boolean
 
   // components
+  builderCreator?: BuilderCreator
   builder?: BuilderComponent
   bullet?: Bullet
   damageable?: Damageable

--- a/src/entities/player/index.ts
+++ b/src/entities/player/index.ts
@@ -7,11 +7,14 @@ import { TILE_SIZE } from '~/constants'
 import { Entity } from '~/entities/Entity'
 import { PlayerRenderables } from '~/entities/player/PlayerRenderables'
 import { Hitbox } from '~/Hitbox'
+import { BuilderCreator } from '~/systems/builder'
 import { ShooterComponent } from '~/systems/shooter'
 
 export const makePlayer = (): Entity => {
   const shooter = new ShooterComponent()
   const e = new Entity()
+
+  e.builderCreator = new BuilderCreator()
   e.transform = new Transform()
   e.shooter = shooter
   e.wallCollider = true


### PR DESCRIPTION
This moves all non-HUD input handling to the playerInput system, in preparation for the initial netplay refactor.